### PR TITLE
Adding reference schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ var jsck = require('jsck');
 var requestValidator = require('request-validator');
 var skeemas = require('skeemas');
 
+var refs = {
+	'http://localhost:1234/integer.json': require('./JSON-Schema-Test-Suite/remotes/integer.json'),
+	'http://localhost:1234/subSchemas.json': require('./JSON-Schema-Test-Suite/remotes/subSchemas.json'),
+	'http://localhost:1234/folder/folderInteger.json': require('./JSON-Schema-Test-Suite/remotes/folder/folderInteger.json'),
+	'http://json-schema.org/draft-03/schema': require('./refs/json-schema-draft-03.json'),
+	'http://json-schema.org/draft-04/schema': require('./refs/json-schema-draft-04.json')
+};
+
 testRunner([
 	{
 		name: 'is-my-json-valid',
@@ -56,7 +64,13 @@ testRunner([
 	{
 		name: 'skeemas',
 		setup: function (schema) {
-			return skeemas;
+			var validator = skeemas();
+
+			Object.keys(refs).forEach(function(uri) {
+				validator.addRef(uri, refs[uri]);
+			});
+
+			return validator;
 		},
 		test: function (instance, json, schema) {
 			return instance.validate(json, schema).valid;

--- a/index.js
+++ b/index.js
@@ -61,7 +61,13 @@ testRunner([
 	{
 		name: 'jjv',
 		setup: function () {
-			return jjv();
+			var validator = jjv();
+
+			Object.keys(refs).forEach(function(uri) {
+				validator.addSchema(uri, refs[uri]);
+			});
+
+			return validator;
 		},
 		test: function (instance, json, schema) {
 			return instance.validate(schema, json) === null;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ testRunner([
 	{
 		name: 'is-my-json-valid',
 		setup: function (schema) {
+			// no $refs supported
 			return imjv(schema);
 		},
 		test: function (instance, json, schema) {
@@ -35,6 +36,7 @@ testRunner([
 	{
 		name: 'themis',
 		setup: function (schema) {
+			// $refs only supported if they have id attributes and the test suite refs do not
 			return Themis.validator(schema);
 		},
 		test: function (instance, json, schema) {
@@ -91,6 +93,7 @@ testRunner([
 	{
 		name: 'jayschema',
 		setup: function () {
+			// $refs not supported with synchronous validation, only asyc
 			return new JaySchema();
 		},
 		test: function (instance, json, schema) {
@@ -100,6 +103,7 @@ testRunner([
 	{
 		name: 'jsck',
 		setup: function (schema) {
+			// no $refs supported
 			return new jsck.draft4(schema);
 		},
 		test: function (instance, json, schema) {
@@ -108,6 +112,7 @@ testRunner([
 	},
 	{
 		name: 'jassi',
+			// no $refs supported
 		setup: function (schema) {
 			return jassi;
 		},
@@ -119,6 +124,7 @@ testRunner([
 	{
 		name: 'JSV',
 		setup: function (schema) {
+			// no documented $refs supported
 			return jsv;
 		},
 		test: function (instance, json, schema) {
@@ -128,6 +134,7 @@ testRunner([
 	{
 		name: 'request-validator',
 		setup: function (schema) {
+			// no documented $refs supported
 			return requestValidator(schema);
 		},
 		test: function (instance, json, schema) {
@@ -143,6 +150,7 @@ testRunner([
 	{
 		name: 'json-model',
 		setup: function (schema) {
+			// no comprehensible documented $refs supported
 			return JsonModel.validator(schema);
 		},
 		test: function (instance, json, schema) {

--- a/index.js
+++ b/index.js
@@ -149,7 +149,13 @@ testRunner([
 	{
 		name: 'jsonschema',
 		setup: function () {
-			return new JsonSchema.Validator();
+			var validator = new JsonSchema.Validator();
+
+			Object.keys(refs).forEach(function(uri) {
+				validator.addSchema(refs[uri], uri);
+			});
+
+			return validator;
 		},
 		test: function (instance, json, schema) {
 			return instance.validate(json, schema).errors.length === 0;

--- a/index.js
+++ b/index.js
@@ -140,6 +140,10 @@ testRunner([
 	{
 		name: 'tv4',
 		setup: function () {
+			Object.keys(refs).forEach(function(uri) {
+				tv4.addSchema(uri, refs[uri]);
+			});
+
 			return tv4;
 		},
 		test: function (instance, json, schema) {

--- a/index.js
+++ b/index.js
@@ -44,9 +44,15 @@ testRunner([
 	{
 		name: 'z-schema',
 		setup: function () {
-			return new ZSchema({
+			var validator = new ZSchema({
 				ignoreUnresolvableReferences: true
 			});
+
+			Object.keys(refs).forEach(function(uri) {
+				validator.setRemoteReference(uri, refs[uri]);
+			});
+
+			return validator;
 		},
 		test: function (instance, json, schema) {
 			return instance.validate(json, schema);

--- a/refs/json-schema-draft-03.json
+++ b/refs/json-schema-draft-03.json
@@ -1,0 +1,174 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+
+    "properties": {
+        "type": {
+            "type": [ "string", "array" ],
+            "items": {
+                "type": [ "string", { "$ref": "#" } ]
+            },
+            "uniqueItems": true,
+            "default": "any"
+        },
+
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+
+        "additionalProperties": {
+            "type": [ { "$ref": "#" }, "boolean" ],
+            "default": {}
+        },
+
+        "items": {
+            "type": [ { "$ref": "#" }, "array" ],
+            "items": { "$ref": "#" },
+            "default": {}
+        },
+
+        "additionalItems": {
+            "type": [ { "$ref": "#" }, "boolean" ],
+            "default": {}
+        },
+
+        "required": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "type": [ "string", "array", { "$ref": "#" } ],
+                "items": {
+                    "type": "string"
+                }
+            },
+            "default": {}
+        },
+
+        "minimum": {
+            "type": "number"
+        },
+
+        "maximum": {
+            "type": "number"
+        },
+
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "minItems": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+
+        "maxItems": {
+            "type": "integer",
+            "minimum": 0
+        },
+
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+
+        "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+
+        "maxLength": {
+            "type": "integer"
+        },
+
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+
+        "default": {
+            "type": "any"
+        },
+
+        "title": {
+            "type": "string"
+        },
+
+        "description": {
+            "type": "string"
+        },
+
+        "format": {
+            "type": "string"
+        },
+
+        "divisibleBy": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "default": 1
+        },
+
+        "disallow": {
+            "type": [ "string", "array" ],
+            "items": {
+                "type": [ "string", { "$ref": "#" } ]
+            },
+            "uniqueItems": true
+        },
+
+        "extends": {
+            "type": [ { "$ref": "#" }, "array" ],
+            "items": { "$ref": "#" },
+            "default": {}
+        },
+
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+
+        "$ref": {
+            "type": "string",
+            "format": "uri"
+        },
+
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        }
+    },
+
+    "dependencies": {
+        "exclusiveMinimum": "minimum",
+        "exclusiveMaximum": "maximum"
+    },
+
+    "default": {}
+}

--- a/refs/json-schema-draft-04.json
+++ b/refs/json-schema-draft-04.json
@@ -1,0 +1,150 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}


### PR DESCRIPTION
I've added the reference schemas required to pass the `$ref` related tests in the suite. Several libraries either do not support references, do not support them properly, or (in the case of jayschema) do not support them with synchronous validation.

For libraries that support refs, this turns quite a few tests green again. This may affect the way you'd like to generate reports as many of the tests that are labeled as "failing for all libraries" are no longer failing for many libs.

I also was unsure about whether or not I should check in the updated reports and README. It might be best if you regenerate them on your side so that I don't have an opportunity to tamper with the results ;)