### PR TITLE
Adding ref schemas to tv4 seems to cause 264 additional test failures so...

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,11 +160,15 @@ testRunner([
 	{
 		name: 'tv4',
 		setup: function () {
-			Object.keys(refs).forEach(function(uri) {
-				tv4.addSchema(uri, refs[uri]);
-			});
+			var validator = tv4.freshApi();
 
-			return tv4;
+			// Adding schemas to tv4 seems to cause many additional test failures
+			// Uncommenting this takes tv4 from 26 failures to 290...
+			// Object.keys(refs).forEach(function(uri) {
+			// 	validator.addSchema(uri, refs[uri]);
+			// });
+
+			return validator;
 		},
 		test: function (instance, json, schema) {
 			return instance.validateResult(json, schema).valid;


### PR DESCRIPTION
...let's not.

This PR should take tv4 from 290 failures back down to 26. Not sure where all the additional test failures come from when the reference schemas are in place...