### PR TITLE
Update template for case where there are no other test failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ testRunner([
 			return validator;
 		},
 		test: function (instance, json, schema) {
-			return instance.validate(json, schema).valid;
+			// third argument is `breakOnError` to halt validation at first error
+			return instance.validate(json, schema, true).valid;
 		}
 	},
 	{

--- a/reports/TESTS.template
+++ b/reports/TESTS.template
@@ -7,9 +7,10 @@
 {{/testsThatAllValidatorsFail}}
 
 
+{{#hasFailingTests}}
 # {{&link}} failed tests
 
-Some validators have deliberately chosen not to support parts of the spec. Go tho the {{&link}} homepage to learn if
+Some validators have deliberately chosen not to support parts of the spec. Go to the {{&link}} homepage to learn if
 that is the case for these tests.
 
 |test failed|reason
@@ -17,5 +18,6 @@ that is the case for these tests.
 {{#failingTests}}
 {{&message}}
 {{/failingTests}}
+{{/hasFailingTests}}
 
 **All other tests passed**.

--- a/testRunner.js
+++ b/testRunner.js
@@ -295,6 +295,7 @@ function saveResults(results, validators, allTestNames, testsThatAllValidatorsFa
 		var html = mustache.render(testsTemplate, {
 			link: validator.link,
 			failingTests: validator.failingTests,
+			hasFailingTests: !!validator.failingTests.length,
 			testsThatAllValidatorsFail: comma(testsThatAllValidatorsFail.map(function (testName) {
 				return {name: testName};
 			}))


### PR DESCRIPTION
- no need to show failed test list when there are none there
- fixed typo in the template `tho` -> `to`
- added `breakOnError` option for skeemas (slight speed up)

Again, I did not check in the updated reports or README. @Muscula, let me know if you'd like me to do this.